### PR TITLE
Add Tag Query

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -42,6 +42,9 @@ export default class IndexPage extends React.Component {
                     {post.excerpt}
                     <br />
                     <br />
+                    {post.frontmatter.tags && post.frontmatter.tags.map(tag => <span>{tag}&nbsp;</span>)}
+                    <br />
+                    <br />
                     <Link className="button is-small" to={post.fields.slug}>
                       Keep Reading →
                     </Link>
@@ -78,6 +81,7 @@ export const pageQuery = graphql`
           }
           frontmatter {
             title
+            tags
             templateKey
             date(formatString: "MMMM DD, YYYY")
           }


### PR DESCRIPTION
@takashiyamakawa 
indexでタグを持ってくる処理を追加しました。

markdownの先頭で

```
---
templateKey: blog-post
title: Making sense of the SCAA’s new Flavor Wheel
date: 2016-12-17T15:04:10.000Z
description: The Coffee Taster’s Flavor Wheel, the official resource used by coffee tasters, has been revised for the first time this year.
tags:
  - flavor
  - tasting
---
```

みたいに保存されている情報を、 `post.frontmatter` というクエリで自由にとってこれるみたいです！